### PR TITLE
added classes for each Particle Type

### DIFF
--- a/particle_simulation/particle_classes.py
+++ b/particle_simulation/particle_classes.py
@@ -1,26 +1,64 @@
 """Particles that use the main particle class
 """
-from particle_simulation.particle_classes import Particle
+from particle_simulation.particle_classes import Particle, ParticleField
 
 
 class Particle_A(Particle):
-    def __init__(self) -> None:
-        pass
-
+    def __init__(self, position):
+        super().__init__(position)
+        self.particle_label = "Particle_A"
+        self.speed = 1
+        self.influence_strength = 10
+        self.influence_radius = 25
+        self.color = Particle.generate_particle_colors(self.particle_label, 1)[0] #gets a colorway for this spicific type (red)
+        self.shape = Particle.generate_particle_shape(self.particle_label)
     self.char
 
 
 class Particle_B(Particle):
-    def __init__(self) -> None:
-        pass        
+    def __init__(self, position):
+        super().__init__(position)
+        self.particle_label = "Particle_B"
+        self.speed = 1
+        self.influence_strength = 10
+        self.influence_radius = 25
+        self.color = Particle.generate_particle_colors(self.particle_label, 1)[0]  #gets a colorway for this spicific type
+        self.shape = Particle.generate_particle_shape(self.particle_label)   
 
 
 class Particle_C(Particle):
-    def __init__(self) -> None:
-        pass        
+    def __init__(self, position):
+        super().__init__(position)
+        self.particle_label = "Particle_C"
+        self.speed = 1
+        self.influence_strength = 10
+        self.influence_radius = 25
+        self.color = Particle.generate_particle_colors(self.particle_label, 1)[0]  #gets a colorway for this spicific type
+        self.shape = Particle.generate_particle_shape(self.particle_label)
+
 
 
 class Particle_D(Particle):
-    def __init__(self) -> None:
-        pass
-        
+    def __init__(self, position):
+        super().__init__(position)
+        self.particle_label = "Particle_D"
+        self.speed = 1
+        self.influence_strength = 10
+        self.influence_radius = 25
+        self.color = Particle.generate_particle_colors(self.particle_label, 1)[0]  #gets a colorway for this spicific type#
+        self.shape = Particle.generate_particle_shape(self.particle_label)
+
+
+if __name__ == "__main__":
+    
+    field = ParticleField(width=200, height=200, num_particles=500)
+
+    fig, ax = field.create_field()
+
+    try:
+        field.start_movement(ax)
+
+    except KeyboardInterrupt:
+        print("\nended simulation")
+
+#use in terminal to run script   -----------> python -m particle_simulation.particle_classes <-----------


### PR DESCRIPTION
Pull Request Description

This PR adds four new particle classes (`Particle_A`, `Particle_B`, `Particle_C`, and `Particle_D`) to the simulation. Each type has unique attributes like speed, influence strength, radius, color, and shape. 

The script initializes a `ParticleField` with 500 particles in a 200x200 area and starts their movement (as an example). 
The simulation handles clean termination with a `KeyboardInterrupt`.

Run in terminal:
python -m particle_simulation.particle_classes
